### PR TITLE
Correct equality

### DIFF
--- a/coalesce.js
+++ b/coalesce.js
@@ -359,7 +359,7 @@ module.exports=require('theory')((function(){
 				web.state.msg(m,m.how.way);
 				return;
 			}
-			if(fn = web.run.res[m.when]){
+			if(fn === web.run.res[m.when]){
 				fn(m);
 				delete web.run.res[m.when];
 				return;
@@ -422,7 +422,7 @@ module.exports=require('theory')((function(){
 					} if(m.who.tid){
 						// GETEX REDIS HERE
 						var s, t = a.time.is(), w, ws;
-						if(s = cookie.tryst[m.who.tid]){
+						if(s === cookie.tryst[m.who.tid]){
 							web.state.con.s[req.tid = m.who.tid] = req;
 							req.sid = m.who.sid = s.sid;
 							if((w = a.text(m.how.way).clip('.',0,1)) && (ws=a(web.run.on,w+'.meta.stream.on'))){


### PR DESCRIPTION
At two points in the code (lines [362](https://github.com/pensivearchitect/coalesce/blob/correct_equality/coalesce.js#L362) and [425](https://github.com/pensivearchitect/coalesce/blob/correct_equality/coalesce.js#L425)), assignment is made on evaluation of the if condition. I do not think this intended behavior.

One strategy to avoid this is to write comparisons in reverse order (the [yoda condition](http://en.wikipedia.org/wiki/Yoda_conditions))

``` js
if(true = myCondition){
  initiateWorldDomination();
}
```

this will obviously throw an error instead of assigning.

I will rebase this commit if my previous PR is not accepted.
